### PR TITLE
Update for use with sfdk target

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,11 @@ Follow these steps to include Opal modules in your project:
         %define __provides_exclude_from ^%{_datadir}/.*$
         # << macros
 
-6. Merge shipped translations with your local translations by running
+6. Merge shipped translations with your local translations. This should be done inside an `sfdk` target, so you'll need to run something like the following (replacing `SailfishOS-4.5.0.16EA-aarch64` with one of your targets).
 
         cd libs
-        ./opal-merge-translations ../translations
+        sfdk engine exec sb2 -t SailfishOS-4.5.0.16EA-aarch64 \
+            ./opal-merge-translations.sh ../translations/
 
 7. Add docs and translations to `.gitignore`. They have been merged with your
    main translations.

--- a/snippets/opal-merge-translations.sh
+++ b/snippets/opal-merge-translations.sh
@@ -65,7 +65,7 @@ for tr in "${app_tr[@]}"; do
     have_extra=false
 
     set -o pipefail
-    lang="$(sed -Ee 's/.*?[-_]([a-z]{2}([-_][A-Z]{2})?)\.[Tt][Ss]/\1/g; T fail; t ok; :ok; q 0; :fail; q 100' <<<"$tr" | tr '_' '-')" || {
+    lang="$(sed -re 's/.*?[-_]([a-z]{2}([-_][A-Z]{2})?)\.[Tt][Ss]/\1/g; T fail; t ok; :ok; q 0; :fail; q 100' <<<"$tr" | tr '_' '-')" || {
         log "skipping '$tr': no language"
         continue
     }


### PR DESCRIPTION
The opal-merge-translations.sh script makes use of lconvert, which for Sailfish OS development is more likely to be installed in an sfdk target than in the user's path. It therefore makes sense to execute the script in the scratbox2 target via sfdk.

Unfortunately the sfdk version of sed doesn't support the -E flag. The -r flag, which is equivalent, is supported. This change therefore changes the script to use -r rather than -E.

The README has also been updated to explain how to run the script using sfdk.